### PR TITLE
Added check if signalGroup has proper shape.

### DIFF
--- a/dd.py
+++ b/dd.py
@@ -346,6 +346,9 @@ class shotfile(object):
         if tEnd==None:
             tEnd = tInfo.tEnd
         k1, k2 = self.getTimeBaseIndices(name, tBegin, tEnd)
+        if info.index[0]!=tInfo.ntVal:
+            k1 = 1
+            k2 = info.index[0]
         size = info.size/info.index[0]*(k2-k1+1)
         print info.size, size
         try:


### PR DESCRIPTION
In case the time is not the first index in the signal group the (e.g. in
IDA) the usage of tBegin and tEnd is disabled. For such signals libddww
does not support reading time slices out of the box. getSignalGroup was
now tested with CEC and IDA and it works properly for both diagnostics.
