### PR TITLE
Access to the creation date of a shotfile

### DIFF
--- a/dd.py
+++ b/dd.py
@@ -5,6 +5,7 @@ from copy import copy
 import warnings
 warnings.simplefilter('always', DeprecationWarning)
 import getpass
+import datetime
 #from IPython import embed
 
 ## \cond
@@ -675,6 +676,7 @@ class shotfile(object):
         getError(error)
         self.shot = int(shot.value)
         self.edition = edit.value
+        self.date = date.value
 
     def close(self):
         """ Close the shotfile. """
@@ -715,6 +717,14 @@ class shotfile(object):
                 counter += 1
             except Exception:
                 return output
+
+    def getShotfileCreationDate(self, format='%d%b%Y;%H:%M:%S'):
+        """ Returns the date of creation of the shotfile as a 
+        datetime.datetime object
+        there are several different formats depending on the diagnostic
+        standard is e.g. '13May2014;14:33:41'
+        """
+        return datetime.datetime.strptime(self.date, format)
 
     def getSignalNames(self):
         """ Return list of all signal names in the shotfile. """

--- a/testdd.py
+++ b/testdd.py
@@ -1,6 +1,7 @@
 import dd
 import unittest
 import numpy
+import datetime
 from IPython import embed
 
 class testdd(unittest.TestCase):
@@ -154,6 +155,16 @@ class testdd(unittest.TestCase):
 	self.assertTrue(sigraw.data[0] == 8195)
 	self.assertTrue(sigraw.data[-1] == 8193)
 	del sf
+
+    def test_getShotfileCreationDate(self):
+        sf = dd.shotfile('MAG', 30774)
+        test_date = datetime.datetime(
+            year=2014, month=5, day=13, hour=14, minute=33, second=41
+        )
+        self.assertEqual(
+            (test_date-sf.getShotfileCreationDate()).total_seconds(), 0.0
+        )
+        del sf
 
 if __name__=='__main__':
     unittest.main()


### PR DESCRIPTION
Added getShotfileCreationDate to the shotfile class to be able to match shotfiles/shotnumbers to other experimental setups via datetime.timedelta.